### PR TITLE
Remove string quotes from zainchas.live env variable check

### DIFF
--- a/src/Services/ZainCash.php
+++ b/src/Services/ZainCash.php
@@ -108,7 +108,7 @@ class ZainCash
     private function sendRequest(array $context)
     {
         try {
-            $apiUrl = config('zaincash.live', 'false') === 'false' ? Local::tUrl() : Live::tUrl();
+            $apiUrl = config('zaincash.live', false) === false ? Local::tUrl() : Live::tUrl();
             $response = Http::asForm()
                 ->post($apiUrl, $context);
 
@@ -138,7 +138,7 @@ class ZainCash
 
     private function createUrl(string $transactionID)
     {
-        $apiUrl = config('zaincash.live', 'false') === 'false' ? Local::rUrl() : Live::rUrl();
+        $apiUrl = config('zaincash.live', false) === false ? Local::rUrl() : Live::rUrl();
         return  $apiUrl . $transactionID;
     }
 


### PR DESCRIPTION
With the quotes, the code returns false at all times.
now the code checks for the actual boolean values.
